### PR TITLE
doc: update non-functional requirements

### DIFF
--- a/doc/requirements/requirements.md
+++ b/doc/requirements/requirements.md
@@ -29,7 +29,7 @@ The software must meet the following functional requirements:
 The software must meet the following non-functional requirements:
 
 - Run on a single host machine with at least 16GB of RAM and 4 CPU cores.
-- Be able to deploy lightweight containers with systemd-nspawn
+- Be able to deploy lightweight containers using Linux namespaces.
 - The software must not introduce a network latency greater than 100ms when an
   attacker interacts with the honeypot.
 - The software must scale the number of available service sessions for attackers


### PR DESCRIPTION
## Summary
We decided not to use Docker as a container solution in favor of nspawn, a more lightweigth solution

## Areas Affected

Non-functional requirements listing is affected, previously stated support of Debian 12 and Docker 27.

## Details

Doesn't support Debian 12 and Docker 27 anymore

## Motivation
Software architecture decision

## Review Checklist

- [x] Spelling and grammar are correct
- [x] All links are working and correct
- [x] Documentation accurately reflects the current state of the project
- [x] Changes are clearly highlighted and easy to understand

