### PR TITLE
doc: update guidelines

### DIFF
--- a/doc/workflow/development.md
+++ b/doc/workflow/development.md
@@ -7,25 +7,23 @@ We follow a Gitflow branching model for its clear history and its structured rel
 
 The branching model is structured as followed:
 
-├── main 
-├── develop 
-├── release
-├── hotfix
-└── feature
-    ├── feature1
-    ├── feature2
-    ├── feature3
-    └── feature4
+```
+├── main
+├── dev
+    ├── hotfix
+    │   ├── hotfix/bugfix1
+    │   └── hotfix/bugfix2
+    ├── feat
+    │   ├── feat/feature1
+    │   └── feat/feature2
+    └── release
+```
 
-`main`: Stores official release history, commits should be tagged with a version number (starting at v0.1)
-
-`develop`: Integration branch, created from main
-
-`release`: Once enough features in `develop`, fork a `release` branch off of `develop`, merge into `develop` and `main` when done. Naming convention is adjectives linked to honey texture
-
-`feature`: Created from `develop`, merges into `develop` when completed
-
-`hotfix`: When issue detected in `main` branch, create a hotfix branch from main, once completed, merge into both `develop` and `main`
+- `main`: Stores official release history, commits should be tagged with a version number (starting at v0.1). The branch must be protected
+- `dev`: Integration branch, created from main. The branch must also be protected
+- `release`: Once enough features in `develop`, fork a `release` branch off of `develop`, merge into `develop` and `main` when done. Naming convention is adjectives linked to honey texture
+- `feat`: Created from `develop`, merges into `develop` when completed
+- `hotfix`: When issue detected in `main` branch, create a hotfix branch from main, once completed, merge into both `develop` and `main`
 
 [More info here](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
 
@@ -104,15 +102,23 @@ To generate the documentation based off of those comments simply run `cargo doc`
 
 As we're working with a small team, handling very small PR is not manageable, try to make PRs as small as possible (so no full features at once), but avoid PRs of less than 50 lines of code. Aim is to point out issues ASAP without overloading the team with review duties
 
-Every PR should be reviewed and validated by an other person than the one opening the PR. We follow a *squash and merge* logic so small commits are taken as one
-
-Every PR from `feature` into `develop` should be reviewed by at least one other team member
-
-Every change made to `main` or `release` branches should be reviewed by all team members
-
-Rotate reviewers on every other PR so the team keeps a global overview of the project
+- Every PR should be reviewed and validated by an other person than the one opening the PR. We follow a *squash and merge* logic so small commits are taken as one
+- Every PR from `feature` into `develop` should be reviewed by at least one other team member
+- Every change made to `main` or `release` branches should be reviewed by all team members
+- Rotate reviewers on every other PR so the team keeps a global overview of the project
+- Depending on the type of PRs (feature addition, bugfix, documentation update) the corresponding template should be used.
 
 [More info](https://blog.mergify.com/pull-request-review-best-practices-code-excellence/)
+
+
+Actual templates lie in `.github/pull_request_template/` and can be used directly when opening a PR by adding the corresponding query parameter to the URL:
+- `?template=feature.md` for feature addition
+- `?template=bugfix.md` for bugfixes
+- `?template=documentation.md` for documentation updates
+
+>[!INFO]
+>
+> If adding the query parameter in the URL doesn't work for you, verify that no other attributes are found at the end of the URL. If that's the case simply remove it and replace it with the *template* one
 
 ## Testing expectations
 
@@ -120,11 +126,8 @@ As Rust integrates testing well, adopting a test-driven development process shou
 
 *Reminder:* You start by writing a test that won't pass (feature not implemented), then you implement the minimal code to make the test pass, then you refactor and add whatever while keeping tests passing
 
-In optimal situation, every Rust file should contain a unit testing section
-
-Integration testing should be done at the same level as the binary code (so not in the lib)
-
-Minimal should be integration testing to prevent error propagation
-
-Performance testing must be done by integrating tools in the source code and
+- In optimal situation, every Rust file should contain a unit testing section
+- Integration testing should be done at the same level as the binary code (so not in the lib)
+- Minimal should be integration testing to prevent error propagation
+- Performance testing must be done by integrating tools in the source code and
 using conditional compilation to run them only in debug mode.

--- a/doc/workflow/team.md
+++ b/doc/workflow/team.md
@@ -14,11 +14,11 @@
 | Software Architect | Responsible for software conception | Esteban |
 
 
-Every team member is responsible for unit testing on its own features before delivering them
+- Every team member is responsible for unit testing on its own features before delivering them
 
-Every team member is responsible for documenting its own features
+- Every team member is responsible for documenting its own features
 
-Even if any team member could work on any part of the application, every member is responsible for a part of the architecture
+- Even if any team member could work on any part of the application, every member is responsible for a part of the architecture
 
 ## Communication
 
@@ -28,20 +28,6 @@ Keeping good and efficient communication between team members is key to consiste
 Daily meetings are attended through the Teams team
 
 Then for questions or remarks that are worth for documenting the project timeline (architecture, conception, etc.) add comments to your issues and ping people you want help from. On the other hand don't forget to frequently verify your Github notifications so you don't miss them
-
-
-
-
-### Submitting a PR
-Depending on the type of PRs (feature addition, bugfix, documentation update) the corresponding template should be used.
-
-
-(Could be added in the `Contributing` section of the README)
-
-Actual templates lie in `.github/pull_request_template/` and can be used directly when opening a PR by adding the corresponding query parameter to the URL:
-- `?template=feature.md` for feature addition
-- `?template=bugfix.md` for bugfixes
-- `?template=documentation.md` for documentation updates
 
 ## Agile methodology
 


### PR DESCRIPTION
## Summary

Moved PR guidelines in one document, transformed paragraphs in lists

## Areas Affected

doc/workflow/team.md

doc/workflow/development.md

## Details

Tree showing branching structure was wrong based on the last PR

Moved all PR guidelines in the development guidelines document and
transformed paragraphs in lists where usefull

## Motivation

Tree now complies with what was validated previously

PR Guidelines are now easier to find

Guidelines in general are easier to read with lists

## Checklist

- [x] Spelling and grammar are correct
- [x] All links are working and correct
- [x] Documentation accurately reflects the current state of the project
- [x] Changes are clearly highlighted and easy to understand