### PR TITLE
fix: set default log level to info

### DIFF
--- a/src/core/src/main.rs
+++ b/src/core/src/main.rs
@@ -18,6 +18,7 @@ async fn main() {
     // Configure logging with specific levels for different modules
     // Respect RUST_LOG environment variable for overall level
     env_logger::Builder::from_default_env()
+        .filter_level(log::LevelFilter::Info) // Default level
         .filter_module("sea_orm", log::LevelFilter::Warn) // Reduce ORM logging
         .filter_module("sqlx", log::LevelFilter::Warn) // Reduce SQLx logging
         .filter_module("sea_orm::query", log::LevelFilter::Error) // Suppress query logs


### PR DESCRIPTION
## Summary

Sets the defaults logging level of the application to `info` if no `RUST_LOG` environment variable is provided.